### PR TITLE
Adapt to new brisk-2.0.5 packaging

### DIFF
--- a/thirdparty/makedeps.sh
+++ b/thirdparty/makedeps.sh
@@ -139,7 +139,7 @@ function get_brisk()
   if [[ ! -f ${brisk_archive} ]]; then
     echo "Downloading ${brisk_archive}"
     wget https://www.doc.ic.ac.uk/~sleutene/software/${brisk_archive}
-    unzip -u ${brisk_archive}
+    unzip -d brisk -u ${brisk_archive}
 
     # apply patches
     patch -Np1 -d brisk -r - < patch/brisk-missing-functional.patch


### PR DESCRIPTION
Fixes #12

brisk-2.0.2.zip downloaded as a dependency contained its files withing a master directory called `brisk`.
In new brisk-2.0.5.zip, that we use, files are directly zipped without a root directory.
