### PR TITLE
Fix dockerfile & add scripts

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,13 @@
 FROM nvidia/cuda:10.0-cudnn7-devel
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Add library path
+ENV LD_LIBRARY_PATH ./thirdparty/install/lib:${LD_LIBRARY_PATH}
+
+# Add nvidia driver settings
+ENV NVIDIA_VISIBLE_DEVICES ${NVIDIA_VISIBLE_DEVICES:-all}
+ENV NVIDIA_DRIVER_CAPABILITIES ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
+
 # Install system dependencies
 RUN set -x && apt-get update -y && apt-get install -y \
       cmake \
@@ -21,6 +28,9 @@ RUN wget -qO - ${TFAPI_URL} | tar -C /usr/local -xvz
 # Build DeepFactors
 COPY . /DeepFactors
 WORKDIR /DeepFactors
+
+# Download pretrained weight
+RUN set -x && bash ./scripts/download_network.bash
 
 # build deps
 RUN set -x && ./thirdparty/makedeps.sh --threads 2

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,1 +1,0 @@
-sudo docker build -t deepfactors -f Dockerfile.ubuntu .

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,1 @@
+sudo docker build -t deepfactors -f Dockerfile.ubuntu .

--- a/scripts/docker/build_docker.sh
+++ b/scripts/docker/build_docker.sh
@@ -1,0 +1,1 @@
+docker build -t deepfactors -f Dockerfile.ubuntu .

--- a/scripts/docker/run_docker.sh
+++ b/scripts/docker/run_docker.sh
@@ -1,0 +1,9 @@
+xhost +local:
+sudo docker run -it \
+    --rm \
+    --runtime=nvidia \
+    -v /home/$(id --user --name):/home/$(id --user --name) \
+    -e DISPLAY=$DISPLAY \
+    -v /tmp/.X11-unix/:/tmp/.X11-unix:ro \
+    deepfactors
+xhost -local:

--- a/scripts/docker/run_docker.sh
+++ b/scripts/docker/run_docker.sh
@@ -1,5 +1,5 @@
 xhost +local:
-sudo docker run -it \
+docker run -it \
     --rm \
     --runtime=nvidia \
     -v /home/$(id --user --name):/home/$(id --user --name) \

--- a/scripts/docker/run_docker.sh
+++ b/scripts/docker/run_docker.sh
@@ -1,8 +1,11 @@
+# You can change this mount directory to your environment.
+DATA_PATH="/home/$(id --user --name)"
+
 xhost +local:
 docker run -it \
     --rm \
     --runtime=nvidia \
-    -v /home/$(id --user --name):/home/$(id --user --name) \
+    -v ${DATA_PATH}:${DATA_PATH} \
     -e DISPLAY=$DISPLAY \
     -v /tmp/.X11-unix/:/tmp/.X11-unix:ro \
     deepfactors

--- a/scripts/download_network.bash
+++ b/scripts/download_network.bash
@@ -7,5 +7,5 @@ if [[ ! -d ${WEIGHT_PATH} ]]; then
   mkdir -p ${WEIGHT_PATH}
   wget -qO - ${URL} | tar xvz -C ${WEIGHT_PATH}
 else
-  echo "Pretrained weights already exists in ${WEIGHT_PATH}!"
+  echo "Pretrained weights have already exist in ${WEIGHT_PATH}!"
 fi

--- a/scripts/download_network.bash
+++ b/scripts/download_network.bash
@@ -1,4 +1,11 @@
 #!/bin/bash
-mkdir -p data/nets
 URL="https://www.dropbox.com/s/fj5dfq9hkqv2hm1/scannet256_32.tar.gz"
-wget -qO - ${URL} | tar xvz -C data/nets 
+WEIGHT_PATH="data/nets"
+
+if [[ ! -d ${WEIGHT_PATH} ]]; then
+  # Download pretrained weights
+  mkdir -p ${WEIGHT_PATH}
+  wget -qO - ${URL} | tar xvz -C ${WEIGHT_PATH}
+else
+  echo "Pretrained weights already exists in ${WEIGHT_PATH}!"
+fi


### PR DESCRIPTION
## Environment
- Ubuntu 18.04
- GeForce GTX 1080
- Docker version 19.03.12, build 48a66213fe

## Issue about this pull request
Hi, I tried to run your DeepFactors on the docker environment.
However, on the docker environment created from your `Dockerfile.ubuntu`, I encountered an error when running demo file.
```sh
$ build/bin/df_demo \
>    --flagfile=data/flags/dataset_odom.flags \
>   --source_url=tum://~/datasets/tum_rgbd/rgbd_dataset_freiburg3_structure_notexture_near/

...

I0808 13:44:50.628271    11 deepfactors.cpp:183] Loading vocabulary from: data/voc/small_voc.yml.gz
I0808 13:44:50.667205    11 live_demo.cpp:129] Entering processing loop
I0808 13:44:50.667223    11 live_demo.cpp:140] Initializing system on the first frame
I0808 13:44:50.667253    50 live_demo.cpp:238] Visualization thread started
libGL error: No matching fbConfigs or visuals found
libGL error: failed to load driver: swrast
X11 Error: BadMatch (invalid parameter attributes)
X11 Error: BadValue (integer parameter out of range for operation)
terminate called after throwing an instance of 'std::runtime_error'
  what():  Pangolin X11: Failed to create an OpenGL context
Aborted (core dumped)
```
In this pull request, I submit a modification of `Dockerfile.ubuntu`  to avoid this error!
In addition, I add scripts for building and running this docker file for convenience (`build_docker.sh` & `run_docker.sh`).

## Contents of this pull request
### 1. Dockerfile.ubuntu
- Related to https://github.com/jczarnowski/DeepFactors/issues/4, set `LD_LIBRARY_PATH` here. ([link](https://github.com/syinari0123/DeepFactors/blob/43116b4cbad3466da7472d48d955c74b9cb4e952/Dockerfile.ubuntu#L5))
```sh
# Add library path
ENV LD_LIBRARY_PATH ./thirdparty/install/lib:${LD_LIBRARY_PATH}
```
- To avoid X11 display error, I add this nvidia driver setting. ([link](https://github.com/syinari0123/DeepFactors/blob/43116b4cbad3466da7472d48d955c74b9cb4e952/Dockerfile.ubuntu#L7-9))
```
# Add nvidia driver settings
ENV NVIDIA_VISIBLE_DEVICES ${NVIDIA_VISIBLE_DEVICES:-all}
ENV NVIDIA_DRIVER_CAPABILITIES ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
```
- This code only supports, inference using pretrained weight. So I download the weight in this docker environment. ([link](https://github.com/syinari0123/DeepFactors/blob/43116b4cbad3466da7472d48d955c74b9cb4e952/Dockerfile.ubuntu#L33))
```sh
RUN set -x && bash ./scripts/download_network.bash
```

### 2. build_docker.sh
- Add a script to build a docker environment. ([link](https://github.com/syinari0123/DeepFactors/blob/43116b4cbad3466da7472d48d955c74b9cb4e952/scripts/docker/build_docker.sh#L1))
```sh
docker build -t deepfactors -f Dockerfile.ubuntu .
```
### 3. run_docker.sh
- Add a script to run docker image. ([link](https://github.com/syinari0123/DeepFactors/blob/43116b4cbad3466da7472d48d955c74b9cb4e952/scripts/docker/run_docker.sh#L1-9))
```sh
xhost +local:
sudo docker run -it \
    --rm \
    --runtime=nvidia \
    -v /home/$(id --user --name):/home/$(id --user --name) \
    -e DISPLAY=$DISPLAY \
    -v /tmp/.X11-unix/:/tmp/.X11-unix:ro \
    deepfactors
xhost -local:
```

## How to use these scripts to create a docker environment
In summary, you can create docker environment using these scripts as follows.
```sh
$ ./scipts/docker/build_docker.sh
$ ./scipts/docker/run_docker.sh
root@35bec0aa4aa2:/DeepFactors# build/bin/df_demo \
> --flagfile=data/flags/dataset_odom.flags \
> --source_url=tum://~/datasets/tum_rgbd/rgbd_dataset_freiburg3_structure_notexture_near/
 ```